### PR TITLE
Hide management cards behind slide-out panel

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,9 +2,11 @@ import React, { useState } from 'react';
 import ComponentList from './components/ComponentList';
 import AddComponentForm from './components/AddComponentForm';
 import SubsystemManager from './components/SubsystemManager';
+import ManagementPanel from './components/ManagementPanel';
 
 function App() {
   const [refreshTrigger, setRefreshTrigger] = useState(0);
+  const [showManagementPanel, setShowManagementPanel] = useState(false);
 
   const handleAddSuccess = () => {
     setRefreshTrigger(prev => prev + 1);
@@ -13,23 +15,30 @@ function App() {
   return (
     <div className="min-h-screen bg-gray-100 dark:bg-gray-900 py-10 px-4 sm:px-6 lg:px-8">
       <div className="max-w-7xl mx-auto">
-        <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-8 text-center">
-          Satellite Components Database
-        </h1>
-        
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
-          <div className="lg:col-span-2">
-            <h2 className="text-xl font-semibold text-gray-800 dark:text-gray-200 mb-4">Component List</h2>
-            <ComponentList refreshTrigger={refreshTrigger} />
-          </div>
-          
-          <div>
-            <h2 className="text-xl font-semibold text-gray-800 dark:text-gray-200 mb-4">Add Component</h2>
-            <AddComponentForm onAddSuccess={handleAddSuccess} />
-            
-            <SubsystemManager />
-          </div>
+        <div className="flex items-center justify-between mb-8">
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
+            Satellite Components Database
+          </h1>
+          <button
+            onClick={() => setShowManagementPanel(true)}
+            className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+          >
+            + Manage
+          </button>
         </div>
+
+        <div>
+          <h2 className="text-xl font-semibold text-gray-800 dark:text-gray-200 mb-4">Component List</h2>
+          <ComponentList refreshTrigger={refreshTrigger} />
+        </div>
+
+        <ManagementPanel
+          isOpen={showManagementPanel}
+          onClose={() => setShowManagementPanel(false)}
+        >
+          <AddComponentForm onAddSuccess={handleAddSuccess} />
+          <SubsystemManager />
+        </ManagementPanel>
       </div>
     </div>
   );

--- a/frontend/src/components/ManagementPanel.jsx
+++ b/frontend/src/components/ManagementPanel.jsx
@@ -1,0 +1,71 @@
+import React, { useEffect } from 'react';
+
+const ManagementPanel = ({ isOpen, onClose, children }) => {
+    // Handle Escape key to close
+    useEffect(() => {
+        const handleKeyDown = (e) => {
+            if (e.key === 'Escape' && isOpen) {
+                onClose();
+            }
+        };
+
+        if (isOpen) {
+            document.addEventListener('keydown', handleKeyDown);
+            // Lock body scroll when panel is open
+            document.body.style.overflow = 'hidden';
+        }
+
+        return () => {
+            document.removeEventListener('keydown', handleKeyDown);
+            document.body.style.overflow = '';
+        };
+    }, [isOpen, onClose]);
+
+    if (!isOpen) return null;
+
+    return (
+        <div className="fixed inset-0 z-50">
+            {/* Backdrop */}
+            <div
+                className="fixed inset-0 bg-black bg-opacity-50 transition-opacity"
+                onClick={onClose}
+            />
+
+            {/* Panel */}
+            <div className="fixed inset-y-0 right-0 max-w-md w-full bg-white dark:bg-gray-800 shadow-xl transform transition-transform duration-300 ease-in-out flex flex-col">
+                {/* Header */}
+                <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 dark:border-gray-700">
+                    <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
+                        Management
+                    </h2>
+                    <button
+                        onClick={onClose}
+                        className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 focus:outline-none focus:ring-2 focus:ring-indigo-500 rounded-md p-1"
+                        aria-label="Close panel"
+                    >
+                        <svg
+                            className="h-6 w-6"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                            stroke="currentColor"
+                        >
+                            <path
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                strokeWidth={2}
+                                d="M6 18L18 6M6 6l12 12"
+                            />
+                        </svg>
+                    </button>
+                </div>
+
+                {/* Scrollable content */}
+                <div className="flex-1 overflow-y-auto p-6">
+                    {children}
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default ManagementPanel;


### PR DESCRIPTION
Move Add Component and Manage Subsystems forms into a slide-out panel that opens via a "Manage" button in the header. This gives the Component List full-width layout and reduces visual clutter.